### PR TITLE
Added hook to update DESCRIPTION file after every commit.

### DIFF
--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -11,6 +11,6 @@ echo "• Updating version number w/pre-commit hash•"
 echo "••••••••••••••••••••••••••••••••••••••••••••"
 sed -i -E "s/^Date: .*/Date: $(date '+%Y-%m-%d')/" DESCRIPTION
 # get latest tags
-preCommitID=`git log --pretty=format:'%h' -n 1`
-sed -i -E "s/^Version: (.*prior.commit-)/Version: \1${new_version}/" DESCRIPTION
+preCommitID=`git log --pretty=format:'%H' -n 1`
+sed -i -E "s/^GitCommitHash: .*/GitCommitHash: ${preCommitID}/" DESCRIPTION
 # 

--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -1,0 +1,16 @@
+# Script to add SHA Hash (commit ID) PRIOR to commit your about to make.
+# The prior value is used because it's impossible to predict what the SHA will be and it will depend on the commit
+# See: https://stackoverflow.com/a/14208345/5322644 for why you have to use the previous one
+# Code Source: https://stackoverflow.com/a/56220622/5322644
+# To use script you need to create a link to it (don't change the name!) in .git/hooks
+#
+
+echo "••••••••••••••••••••••••••••••••••••••••••••"
+echo "• Updating package date
+echo "• Updating version number w/pre-commit hash•"
+echo "••••••••••••••••••••••••••••••••••••••••••••"
+sed -i -E "s/^Date: .*/Date: $(date '+%Y-%m-%d')/" DESCRIPTION
+# get latest tags
+preCommitID=`git log --pretty=format:'%h' -n 1`
+sed -i -E "s/^Version: (.*prior.commit-)/Version: \1${new_version}/" DESCRIPTION
+# 

--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -5,12 +5,15 @@
 # To use script you need to create a link to it (don't change the name!) in .git/hooks
 #
 
-echo "••••••••••••••••••••••••••••••••••••••••••••"
-echo "• Updating package date
-echo "• Updating version number w/pre-commit hash•"
-echo "••••••••••••••••••••••••••••••••••••••••••••"
-sed -i -E "s/^Date: .*/Date: $(date '+%Y-%m-%d')/" DESCRIPTION
-# get latest tags
 preCommitID=`git log --pretty=format:'%H' -n 1`
-sed -i -E "s/^GitCommitHash: .*/GitCommitHash: ${preCommitID}/" DESCRIPTION
+curDate=`date '+%Y-%m-%d'`
+
+echo "••••••••••••••••••••••••••••••••••••••••••••"
+echo "• Updating package date to ${curDate}"
+echo "• Updating version number w/current, pre-commit hash" 
+echo "•      ${preCommitID} •"
+echo "••••••••••••••••••••••••••••••••••••••••••••"
+sed -i -- "s/^Date: .*/Date: ${curDate}/" DESCRIPTION
+# get latest tags
+sed -i -- "s/^GitCommitHash: .*/GitCommitHash: ${preCommitID}/" DESCRIPTION
 # 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,8 @@ Package: AnaCoDa
 Type: Package
 Title: Analysis of Codon Data under Stationarity using a Bayesian
         Framework
-Version: 0.1.4.0_prior.commit-976bd995f
+Version: 0.1.4.0
+GitHash: 53de60edf953d1d9230bcaf51887bf26ac83c623
 Date: 2020-09-11
 Author: c(person("Cedric", "Landerer", role = c("aut", "cre"), email
         = "cedric.landerer@gmail.com"), person("Gabriel", "Hanas", role
@@ -37,3 +38,4 @@ LinkingTo: Rcpp
 LazyLoad: yes
 LazyData: yes
 RoxygenNote: 7.1.1
+

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,8 +3,8 @@ Type: Package
 Title: Analysis of Codon Data under Stationarity using a Bayesian
         Framework
 Version: 0.1.4.0
-GitCommitHash: a44e61bc6aed82cfe672652403b2970342464918
-Date: 2021-11-15
+GitCommitHash: 248234f52fc73d5bf5e166a9de04d99606b4f2e1
+Date: 2021-12-18
 Author: c(person("Cedric", "Landerer", role = c("aut", "cre"), email
         = "cedric.landerer@gmail.com"), person("Gabriel", "Hanas", role
         = "ctb"), person("Jeremy", "Rogers", role = "ctb"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,8 +3,8 @@ Type: Package
 Title: Analysis of Codon Data under Stationarity using a Bayesian
         Framework
 Version: 0.1.4.0
-GitHash: 53de60edf953d1d9230bcaf51887bf26ac83c623
-Date: 2020-09-11
+GitCommitHash: 105f95d5c91018be85d0ef6d90049cf13b7b40c7
+Date: 2021-11-15
 Author: c(person("Cedric", "Landerer", role = c("aut", "cre"), email
         = "cedric.landerer@gmail.com"), person("Gabriel", "Hanas", role
         = "ctb"), person("Jeremy", "Rogers", role = "ctb"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: AnaCoDa
 Type: Package
 Title: Analysis of Codon Data under Stationarity using a Bayesian
         Framework
-Version: 0.1.4.0
+Version: 0.1.4.0_prior.commit-976bd995f
 Date: 2020-09-11
 Author: c(person("Cedric", "Landerer", role = c("aut", "cre"), email
         = "cedric.landerer@gmail.com"), person("Gabriel", "Hanas", role

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,13 +3,14 @@ Type: Package
 Title: Analysis of Codon Data under Stationarity using a Bayesian
         Framework
 Version: 0.1.4.0
-GitCommitHash: 105f95d5c91018be85d0ef6d90049cf13b7b40c7
+GitCommitHash: a44e61bc6aed82cfe672652403b2970342464918
 Date: 2021-11-15
 Author: c(person("Cedric", "Landerer", role = c("aut", "cre"), email
         = "cedric.landerer@gmail.com"), person("Gabriel", "Hanas", role
         = "ctb"), person("Jeremy", "Rogers", role = "ctb"),
-        person("Alex", "Cope", role="ctb"), person("Denizhan", "Pak", role="ctb"))
-Maintainer: Cedric Landerer <cedric.landerer@gmail.com>
+        person("Alex", "Cope", role="aut", "ctb"), person("Denizhan", "Pak", role="ctb",
+        person("Michael", "Gilchrist", role="ctb", email = "mikeg@utk.edu"))
+Maintainer: Alex Cope  <alexandercope0@gmail.com>
 URL: https://github.com/clandere/AnaCoDa
 VignetteBuilder: knitr
 NeedsCompilation: yes

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,8 @@ Type: Package
 Title: Analysis of Codon Data under Stationarity using a Bayesian
         Framework
 Version: 0.1.4.0
-GitCommitHash: 248234f52fc73d5bf5e166a9de04d99606b4f2e1
+PreviousGitCommitHash: ad2611c3611ec51486d0654ec56c7a5ff25a416c
+                        The above is the hash for the previous commit
 Date: 2021-12-18
 Author: c(person("Cedric", "Landerer", role = c("aut", "cre"), email
         = "cedric.landerer@gmail.com"), person("Gabriel", "Hanas", role


### PR DESCRIPTION
Trying to improve replicability of work by including the most recent commit ID (i.e. the hash ID for the previous commit) and commit date in the DESCRIPTIONS file.

Approach: 

- Created .githooks directory in top directory.
- Made simple script that uses sed to update information
- Users can run script directly using ./githooks/post-commit.
  Ideally, user creates a link to the file .githooks/post-commit in the .git/hooks to get it to work automatically
