### PR TITLE
tests for writing and loading MCMC objects

### DIFF
--- a/tests/testthat/testMCMCROC.R
+++ b/tests/testthat/testMCMCROC.R
@@ -75,6 +75,28 @@ test_that("identical MCMC-ROC input with Phi, same log posterior", {
   expect_equal(knownLogPosterior, testLogPosterior)
 })
 
+
+#added by Elizabeth Barnes - Aug. 15 2022
+
+mcmcSaveFile = file.path("UnitTestingOut", "testMCMCROCobject.Rda")
+
+writeMCMCObject(mcmc = mcmc, file = mcmcSaveFile)
+
+test_that("object can be written successfully: mcmc", {
+  expect_equal(file.exists(mcmcSaveFile), T)
+})
+
+#test works!
+
+test_that("object can be loaded successfully: mcmc", {
+  mcmcSaved <- loadMCMCObject(file = mcmcSaveFile)
+  expect_equal(length(mcmcSaved), 1)
+})
+
+#if object exists, it will have a length of 1 when loaded into R
+#would like to implement test comparing log posterior trace of original mcmc and mcmc object that has been saved and loaded
+
+
 ### Without Phi
 set.seed(446141)
 

--- a/tests/testthat/testMCMCROC.R
+++ b/tests/testthat/testMCMCROC.R
@@ -63,7 +63,7 @@ parameter$initMutationCategories(c(mutationMainFile, mutationHtFile), 2,F)
 
 model <- initializeModelObject(parameter, "ROC", with.phi = TRUE) 
 
-outFile = file.path("UnitTestingOut", "testMCMCROCLogPhi.txt")
+outFile <- file.path("UnitTestingOut", "testMCMCROCLogPhi.txt")
 
 sink(outFile)
 runMCMC(mcmc, genome, model, 1, divergence.iteration)
@@ -76,25 +76,34 @@ test_that("identical MCMC-ROC input with Phi, same log posterior", {
 })
 
 
-#added by Elizabeth Barnes - Aug. 15 2022
 
-mcmcSaveFile = file.path("UnitTestingOut", "testMCMCROCobject.Rda")
+Gilchrist, Michael Aaron
+11:06 AM (3 hours ago)
 
-writeMCMCObject(mcmc = mcmc, file = mcmcSaveFile)
+to me
+
+## 2022-08-15: tests for saving and loading mcmc object added by Elizabeth Barnes and Mike Gilchrist
+
+## Notes:
+##   - When using a brand new mcmc object (not one loaded or extended), the first LogPosteriorTrace() and LogLikelihoodTrace() values are both 0.
+##   - Not sure if this is a bug or intentional.  If it's intentional, then we should simply alter the test for the objects that are saved and then reloaded.
+
+mcmcSaveFile <- file.path("UnitTestingOut", "testMCMCROCobject.Rda")
 
 test_that("object can be written successfully: mcmc", {
-  expect_equal(file.exists(mcmcSaveFile), T)
+  expect_null(writeMCMCObject(mcmc = mcmc, file = mcmcSaveFile))
 })
-
-#test works!
 
 test_that("object can be loaded successfully: mcmc", {
-  mcmcSaved <- loadMCMCObject(file = mcmcSaveFile)
-  expect_equal(length(mcmcSaved), 1)
+  expect_silent(mcmcSaved <- loadMCMCObject(file = mcmcSaveFile))  
 })
 
-#if object exists, it will have a length of 1 when loaded into R
-#would like to implement test comparing log posterior trace of original mcmc and mcmc object that has been saved and loaded
+test_that("object trace matches expected length of (samples + 1): mcmc",{
+  expect_equal(
+    length(mcmcSaved$getLogPosteriorTrace()), (samples+1) )
+})
+
+### end tests by Elizabeth Barnes and Mike Gilchrist
 
 
 ### Without Phi

--- a/tests/testthat/testMCMCROC.R
+++ b/tests/testthat/testMCMCROC.R
@@ -76,12 +76,6 @@ test_that("identical MCMC-ROC input with Phi, same log posterior", {
 })
 
 
-
-Gilchrist, Michael Aaron
-11:06 AM (3 hours ago)
-
-to me
-
 ## 2022-08-15: tests for saving and loading mcmc object added by Elizabeth Barnes and Mike Gilchrist
 
 ## Notes:

--- a/tests/testthat/testMCMCROC.R
+++ b/tests/testthat/testMCMCROC.R
@@ -17,6 +17,7 @@ selectionMainFile = file.path("UnitTestingData", "testMCMCROCFiles", "selection_
 selectionHtFile = file.path("UnitTestingData", "testMCMCROCFiles", "selection_2.csv")
 mutationMainFile = file.path("UnitTestingData", "testMCMCROCFiles", "mutation_1.csv")
 mutationHtFile = file.path("UnitTestingData", "testMCMCROCFiles", "mutation_2.csv")
+mcmcSaveFile <- file.path("UnitTestingOut", "testMCMCROCobject.Rda")
 
 # Ensure the input files exist.
 test_that("file exists: simulatedAllUniqueR.fasta", {
@@ -81,8 +82,6 @@ test_that("identical MCMC-ROC input with Phi, same log posterior", {
 ## Notes:
 ##   - When using a brand new mcmc object (not one loaded or extended), the first LogPosteriorTrace() and LogLikelihoodTrace() values are both 0.
 ##   - Not sure if this is a bug or intentional.  If it's intentional, then we should simply alter the test for the objects that are saved and then reloaded.
-
-mcmcSaveFile <- file.path("UnitTestingOut", "testMCMCROCobject.Rda")
 
 test_that("object can be written successfully: mcmc", {
   expect_null(writeMCMCObject(mcmc = mcmc, file = mcmcSaveFile))
@@ -194,6 +193,13 @@ sink(outFile)
 runMCMC(mcmc, genome, model, 1, divergence.iteration)
 sink()
 
+## 2022-08-17: tests for saving and loading mcmc object added by Elizabeth Barnes and Mike Gilchrist
+
+test_that("object can be written successfully: mcmc", {
+  expect_null(writeMCMCObject(mcmc = mcmc, file = outFile))
+})
+
+### end tests by Elizabeth Barnes and Mike Gilchrist
 
 aa <- aminoAcids()
 test_that("Making sure DeltaEta does not change when fixed", {


### PR DESCRIPTION
Added code for testing whether MCMC objects can be written and loaded successfully. Only currently included are cases with phi. Testing for cases without phi and also for writing and loading parameter objects should be added as well. Also included are notes on observation of 0 value for `LogPosteriorTrace()` and `LogLikelihoodTrace()` when using new MCMC object.